### PR TITLE
Add display-mode media query

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -677,6 +677,7 @@ keywordSets.mediaFeatureNames = uniteSets(keywordSets.deprecatedMediaFeatureName
 	'color-gamut',
 	'color-index',
 	'dynamic-range',
+	'display-mode',
 	'forced-colors',
 	'grid',
 	'height',


### PR DESCRIPTION
This is a new media query added to CSS Media Queries Level 5 to test the display mode of an application.

Closes #6071